### PR TITLE
feat: allows the configuration of jetty to use ssl

### DIFF
--- a/openvoxdb/docker-entrypoint.d/20-configure-ssl.sh
+++ b/openvoxdb/docker-entrypoint.d/20-configure-ssl.sh
@@ -16,3 +16,7 @@ if [ -w "$SSLDIR" ] && [ "$(id -un)" = "root" ]; then
   echo "Setting ownership for $SSLDIR to puppetdb:puppetdb"
   chown -R puppetdb:puppetdb ${SSLDIR}
 fi
+if [ "$USE_USER_CERTIFICATE" = true]; then
+  # enable SSL in Jetty
+  sed -i '/^# ssl-/s/^# //g' /etc/puppetlabs/puppetdb/conf.d/jetty.ini
+fi


### PR DESCRIPTION
There is at the moment no way to configure openvox to use ssl if a  certificate is configured by the user himself. 