### PR TITLE
fix: allows the execution of initscripts.

### DIFF
--- a/openvoxdb/docker-entrypoint.sh
+++ b/openvoxdb/docker-entrypoint.sh
@@ -10,10 +10,7 @@ done
 
 if [ -d /docker-custom-entrypoint.d/ ]; then
     find /docker-custom-entrypoint.d/ -type f -name "*.sh" \
-        -exec chmod +x {} \;
-    sync
-    find /docker-custom-entrypoint.d/ -type f -name "*.sh" \
-        -exec echo Running {} \; -exec {} \;
+        -exec echo Running {} \; -exec bash {} \;
 fi
 
 exec /opt/puppetlabs/bin/puppetdb "$@"


### PR DESCRIPTION
Only using find to execute kubernetes-mounted scripts does not work when coming from a configmap ( no +x ). explicitly using bash