### PR TITLE
Modify host command in wait-for-hosts.sh

### DIFF
--- a/openvoxdb/container-entrypoint.d/10-wait-for-hosts.sh
+++ b/openvoxdb/container-entrypoint.d/10-wait-for-hosts.sh
@@ -33,7 +33,7 @@ wait_for_host_name_resolution() {
   # k8s nodes may not be reachable with a ping
   # performing a dig prior to a host may help prime the cache in Alpine
   # https://github.com/Microsoft/opengcs/issues/303
-  /wtfc.sh --timeout="${2}" --interval=1 --progress "dig $1 && host -t A $1"
+  /wtfc.sh --timeout="${2}" --interval=1 --progress "dig $1 && host $1"
   # additionally log the DNS lookup information for diagnostic purposes
   NAME_RESOLVED=$?
   dig $1


### PR DESCRIPTION
Updated the command to use host without specifying a record type to ensure IPv6 compatibility.