### PR TITLE
Change netcat package from traditional to openbsd

### DIFF
--- a/openvoxdb/Containerfile
+++ b/openvoxdb/Containerfile
@@ -15,6 +15,7 @@ LABEL org.label-schema.maintainer="Voxpupuli Release Team <voxpupuli@groups.io>"
       org.label-schema.vcs-ref="$vcs_ref" \
       org.label-schema.build-date="$build_date"
 
+# Use netcat-openbsd to support IPv6 connectivity checks (netcat-traditional is IPv4 only)
 ARG PACKAGES="ca-certificates curl dnsutils netcat-openbsd dumb-init"
 
 ARG LOGDIR


### PR DESCRIPTION
### Description
This PR replaces the `netcat-traditional` package with `netcat-openbsd` in the Containerfile.

### Reasoning
The `netcat-traditional` package does not support IPv6. In many Kubernetes/OKD environments (especially dual-stack or IPv6-only clusters), internal service DNS names (like the PostgreSQL service) often resolve to IPv6 addresses.

As a result, connectivity checks using `nc -z` fail silently or timeout because `netcat-traditional` cannot handle the IPv6 address returned by the DNS, causing the container startup to fail even when the database is reachable.

`netcat-openbsd` is the standard replacement on Debian/Ubuntu, fully supports IPv6, and automatically handles the `nc` command alias via the alternatives system.