### PR TITLE
fix: ensure $LOGDIR exists at runtime for PVC-mounted deployments

### DIFF
--- a/openvoxdb/container-entrypoint.d/35-create-logdir.sh
+++ b/openvoxdb/container-entrypoint.d/35-create-logdir.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Ensure the log directory exists at runtime.
+#
+# The Containerfile creates $LOGDIR during the image build, but when a
+# PersistentVolumeClaim (PVC) is mounted at the parent path
+# /opt/puppetlabs/server/data/puppetdb/ (common in Kubernetes), the mount
+# overlays the entire directory with an empty volume — erasing the logs/
+# subdirectory that was created at build time.
+#
+# Without this, the JVM fails fatally on startup:
+#   Error opening log file '$LOGDIR/puppetdb_gc.log': No such file or directory
+#   Error: Could not create the Java Virtual Machine.
+
+mkdir -p "${LOGDIR}"
+chown puppetdb:puppetdb "${LOGDIR}"


### PR DESCRIPTION
## Summary

When deploying the openvoxdb container in Kubernetes with a PersistentVolumeClaim (PVC) mounted at `/opt/puppetlabs/server/data/puppetdb/`, the JVM fails to start on every fresh deployment because the `$LOGDIR` directory (`/opt/puppetlabs/server/data/puppetdb/logs/`) does not exist on the empty volume.

The Containerfile already creates `$LOGDIR` at build time:
```dockerfile
mkdir -p "$LOGDIR" && \
chown puppetdb:puppetdb "$LOGDIR" && \
```

However, in Kubernetes, a PVC mount overlays the entire parent directory with an empty volume, erasing the `logs/` subdirectory that was created during the image build.

## Fix

Adds `35-create-logdir.sh` to the container entrypoint scripts, which runs `mkdir -p "$LOGDIR"` before the JVM starts. This follows the existing numbered script convention (`10-wait-for-hosts.sh`, `20-configure-ssl.sh`, `30-certificate-allowlist.sh`) and is idempotent — if the directory already exists (no PVC, or subsequent boots), it's a no-op.

## Affected Versions

Tested and confirmed on `8.9.0-main`, `8.11.0-main`, and `8.12.1-latest`.

## Error Without Fix

```
[0.001s][error][logging] Error opening log file '/opt/puppetlabs/server/data/puppetdb/logs/puppetdb_gc.log': No such file or directory
[0.001s][error][logging] Initialization of output 'file=/opt/puppetlabs/server/data/puppetdb/logs/puppetdb_gc.log' using options '(null)' failed.
Invalid -Xlog option '-Xlog:gc*:file=/opt/puppetlabs/server/data/puppetdb/logs/puppetdb_gc.log', see error log for details.
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

## Workaround (Current)

Users can work around this with the Helm chart's `extraInitContainers`:

```yaml
puppetdb:
  extraInitContainers:
    - name: create-log-dir
      image: busybox:1.37
      command: ["sh", "-c", "mkdir -p /data/logs && chown 999:999 /data/logs"]
      volumeMounts:
        - name: puppetdb-storage
          mountPath: /data
```

## Environment

- Helm chart: `openvox/puppetserver` v10.0.1
- Kubernetes: GKE v1.33
- Storage: `standard-rwo` (pd.csi.storage.gke.io), ReadWriteOnce PVCs
- PostgreSQL: Cloud SQL PostgreSQL 16 (external, private IP)